### PR TITLE
Re-add removed metrics.NewMeterForced

### DIFF
--- a/metrics/meter.go
+++ b/metrics/meter.go
@@ -51,6 +51,21 @@ func NewMeter() Meter {
 	return m
 }
 
+// NewMeterForced constructs a new StandardMeter and launches a goroutine no matter
+// the global switch is enabled or not.
+// Be sure to call Stop() once the meter is of no use to allow for garbage collection.
+func NewMeterForced() Meter {
+	m := newStandardMeter()
+	arbiter.Lock()
+	defer arbiter.Unlock()
+	arbiter.meters[m] = struct{}{}
+	if !arbiter.started {
+		arbiter.started = true
+		go arbiter.tick()
+	}
+	return m
+}
+
 // NewInactiveMeter returns a meter but does not start any goroutines. This
 // method is mainly intended for testing.
 func NewInactiveMeter() Meter {


### PR DESCRIPTION
Opera/Sonic use this meter for events emitting timing, therefore it needs to have this metric enabled even when regular monitoring metrics are disabled.

The usage in emitter:
https://github.com/Fantom-foundation/Sonic/blob/836c2eddcfb0680cee3b9f764fc328ec23dc71ae/gossip/emitter/emitter.go#L410